### PR TITLE
feat: add OpenTelemetry attributes for database operations in nebulex

### DIFF
--- a/instrumentation/opentelemetry_nebulex/test/opentelemetry_nebulex_test.exs
+++ b/instrumentation/opentelemetry_nebulex/test/opentelemetry_nebulex_test.exs
@@ -68,7 +68,10 @@ defmodule OpentelemetryNebulexTest do
     assert %{
              "nebulex.action": :miss,
              "nebulex.backend": :ets,
-             "nebulex.cache": OpentelemetryNebulexTest.Local
+             "nebulex.cache": OpentelemetryNebulexTest.Local,
+             "db.system": :ets,
+             "db.operation": :get,
+             "db.statement": "GET :my_key"
            } = :otel_attributes.map(attributes)
 
     # write
@@ -125,7 +128,10 @@ defmodule OpentelemetryNebulexTest do
 
     assert %{
              "nebulex.backend": :ets,
-             "nebulex.cache": OpentelemetryNebulexTest.Partitioned.Primary
+             "nebulex.cache": OpentelemetryNebulexTest.Partitioned.Primary,
+             "db.system": :ets,
+             "db.operation": :put,
+             "db.statement": "PUT :my_key"
            } = :otel_attributes.map(attributes)
 
     assert_receive {:span, span(name: "nebulex put", kind: :internal, attributes: attributes)}


### PR DESCRIPTION
- Introduced new attributes for tracing database operations, including `db.system`, `db.operation`, and `db.statement`.
- Updated the `OpentelemetryNebulex` module to include these attributes in the telemetry data.
- Enhanced test cases to validate the inclusion of new attributes in the generated telemetry data.