### PR TITLE
chore: fallback to redis for db.system in opentelemetry_nebulex

### DIFF
--- a/instrumentation/opentelemetry_nebulex/lib/opentelemetry_nebulex.ex
+++ b/instrumentation/opentelemetry_nebulex/lib/opentelemetry_nebulex.ex
@@ -69,7 +69,7 @@ defmodule OpentelemetryNebulex do
     attributes =
       %{
         :"nebulex.cache" => metadata.adapter_meta.cache,
-        Trace.db_system() => metadata.adapter_meta[:backend],
+        Trace.db_system() => metadata.adapter_meta[:backend] || "redis",
         Trace.db_operation() => db_operation(metadata),
         Trace.db_statement() => db_statement(metadata)
       }


### PR DESCRIPTION
Description: Default db.system to "redis" when `adapter_meta[:backend]` is not set. `NebulexRedisAdapter` doesn't include `:backend` in its adapter metadata, causing `db.system` to be explicitly set to `nil` on all `GlobalCache` spans. This results in Datadog showing the span operation name as `nil`.